### PR TITLE
Change Full description to high

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # leetfy
-Leetfy encodes and transforms your text in leet using low frequency leetcode, or full frequency leetcode.
+Leetfy encodes and transforms your text in leet using low frequency leetcode, or high frequency leetcode.
 Low frequency leetcode is good for passwords, as you aren't using a full leet dialect, and it can enhance your passwords quality.
 
 * **Install**
@@ -23,7 +23,7 @@ Leetfy your texts
 Usage: leetfy [OPTIONS] <MODE>
 
 Arguments:
-  <MODE>  The dictionary type [possible values: low, full]
+  <MODE>  The dictionary frequency [possible values: low, high]
 
 Options:
   -f, --filename <filename>  Read from a file
@@ -40,7 +40,7 @@ th3 qu1ck 8r0wn f0x jump5 0v3r th3 l4zy d0g
 
 * **From file**
 ```
-$ leetfy --filename ~/Documents/Caderno_de_poesias.txt full
+$ leetfy --filename ~/Documents/Caderno_de_poesias.txt high
 C4)32~0 )3 ?035145
 
 C4)32~0 )3 ?035145

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -3,12 +3,12 @@ use std::{collections::HashMap, sync::OnceLock};
 use clap::ValueEnum;
 
 static ALPHABET_LOW_FREQUENCY: OnceLock<HashMap<char, char>> = OnceLock::new();
-static ALPHABET_FULL_FREQUENCY: OnceLock<HashMap<char, char>> = OnceLock::new();
+static ALPHABET_HIGH_FREQUENCY: OnceLock<HashMap<char, char>> = OnceLock::new();
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Frequency {
     Low,
-    Full,
+    High,
 }
 
 fn load() {
@@ -23,7 +23,7 @@ fn load() {
         m
     });
 
-    let _ = ALPHABET_FULL_FREQUENCY.get_or_init(|| {
+    let _ = ALPHABET_HIGH_FREQUENCY.get_or_init(|| {
         let mut m = HashMap::<char, char>::new();
         m.insert('a', '4');
         m.insert('b', '8');
@@ -69,7 +69,7 @@ pub fn encodestr(frequency: Frequency, data: &str) -> String {
     load();
     let result = match frequency {
         Frequency::Low => encode(ALPHABET_LOW_FREQUENCY.get().unwrap(), data),
-        Frequency::Full => encode(ALPHABET_FULL_FREQUENCY.get().unwrap(), data),
+        Frequency::High => encode(ALPHABET_HIGH_FREQUENCY.get().unwrap(), data),
     };
     result
 }
@@ -85,7 +85,7 @@ mod tests {
         let full_frequency = "+#3 9v1[x 820w~ f0* ]vm?5 0v32 +#3 142j )06";
         let result = encodestr(super::Frequency::Low, data);
         assert_eq!(low_frequency, result);
-        let result = encodestr(super::Frequency::Full, data);
+        let result = encodestr(super::Frequency::High, data);
         assert_eq!(full_frequency, result);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use crate::alphabet::{encodestr, Frequency};
 #[derive(Parser)]
 #[command(author, version, about, long_about=None)]
 struct Cli {
-    /// The dictionary type
+    /// The dictionary frequency
     #[arg(value_enum)]
     mode: Frequency,
     /// Read from a file
@@ -38,7 +38,7 @@ pub fn execute_cli() -> Result<()> {
 
     let result = match cli.mode {
         Frequency::Low => encodestr(Frequency::Low, data.as_str()),
-        Frequency::Full => encodestr(Frequency::Full, data.as_str()),
+        Frequency::High => encodestr(Frequency::High, data.as_str()),
     };
     print!("{result}");
 


### PR DESCRIPTION
This refactor was made to make more clear to users what they are using. Full word is not so clear, then it was changed to high.