### PR TITLE
Fix flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leetfy"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Leetfy your texts"
 authors = ["Julio Gardona <jcbritobr@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -26,15 +26,14 @@ Arguments:
   <MODE>  The dictionary frequency [possible values: low, high]
 
 Options:
-  -f, --filename <filename>  Read from a file
-  -s, --stdin                Read from stdin
+  -f, --filename <filename>  Read from file. If not present, read from stdin
   -h, --help                 Print help
   -V, --version              Print version
 ```
 
 * **From stdin**
 ```
-$ echo "the quick brown fox jumps over the lazy dog" | leetfy -s low
+$ echo "the quick brown fox jumps over the lazy dog" | leetfy low
 th3 qu1ck 8r0wn f0x jump5 0v3r th3 l4zy d0g
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,12 +11,9 @@ struct Cli {
     /// The dictionary frequency
     #[arg(value_enum)]
     mode: Frequency,
-    /// Read from a file
-    #[arg(name = "filename", short, long)]
+    /// Read from file. If not present, read from stdin
+    #[arg(short, long)]
     filename: Option<String>,
-    /// Read from stdin
-    #[arg(short, long, conflicts_with = "filename")]
-    stdin: bool,
 }
 
 fn read_data_from<R: Read>(reader: &mut R) -> Result<String> {
@@ -82,14 +79,14 @@ mod tests {
     }
 
     #[test]
-    fn test_cmd_leetfy_full_frequency() {
+    fn test_cmd_leetfy_high_frequency() {
         let mut cmd = Command::cargo_bin("leetfy")
             .context("we need assert that the binary leetfy is available")
             .unwrap();
         let test = cmd
             .arg("--filename")
             .arg("tests/text.txt")
-            .arg("full")
+            .arg("high")
             .assert();
         test.success().stdout(predicates::str::contains(
             "+#3 9v1[x 820w~ f0* ]vm?5 0v32 +#3 142j )06",


### PR DESCRIPTION
This commit fix an issue with the both flags stdin, file. There is no need to stdin flag exists, as we can use filename on/off. Fix a test issue with wrong frequency type.